### PR TITLE
Missing comma in install snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Lazy:
 
 ```lua
 {
-    "Febri-i/snake.nvim"
+    "Febri-i/snake.nvim",
     dependencies = {
         "Febri-i/fscreen.nvim"
     },


### PR DESCRIPTION
Just a missing comma in example config for lazy.nvim in README